### PR TITLE
Set up defaults for all options; list fonts

### DIFF
--- a/bingo.py
+++ b/bingo.py
@@ -131,16 +131,14 @@ class Page:
 
 if __name__ == '__main__':
 	parser = argparse.ArgumentParser()
-	parser.add_argument('-t', '--font-type',
-		help='TrueType font file to use',
-		required=True)
+	parser.add_argument('-t', '--font-type', default="times.ttf",
+		            help='TrueType font file to use. Default=%(default)s')
 	parser.add_argument('-s', '--font-size',
-		help='Font size (default=%(default)s)',
-		default=10,
+		help='Font size. Default=%(default)s',
+		default=15,
 		type=int)
-	parser.add_argument('-o', '--output',
-		help='Name of output pdf file (will overwrite without asking)',
-		required=True)
+	parser.add_argument('-o', '--output', default="card0.pdf",
+		help='Name of output pdf file (will overwrite without asking). Default=%(default)s')
 	args = parser.parse_args()
 	if args.font_type:
 		pdfmetrics.registerFont(TTFont(


### PR DESCRIPTION
The default font I've chosen,  `times.ttf`, works on Ubuntu 18.04.
But I don't know if it works cross-platform.

I have added a partial way to list fonts now, via a new `-q` option. For me it lists e.g.:
```
 Times-Italic
 Times-Roman
```
But to make it work, I have to use a `-f` option like `times.ttf`, so I'm still unclear on how to list the font options as they seem to need to be specified.